### PR TITLE
Add attribution for local inference instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # appbuildagent-examples
-Code examples for local app.build/agent usage
+Code examples for local app.build/agent usage.
+
+The recommended local setup is based on guidance from [OwnYourAI](https://www.linkedin.com/in/ownyourai?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app).
+
+See [local_inference_setup.md](local_inference_setup.md) for details on running the agent with `llama.cpp`.
+
+Experiment ideas are listed in [experiments_plan.md](experiments_plan.md).

--- a/experiments_plan.md
+++ b/experiments_plan.md
@@ -1,0 +1,44 @@
+# App.build Agent Experiments Plan
+
+This document lists experiments to evaluate app.build with both cloud and local LLMs.
+
+## How to Run the Agent
+
+```bash
+cd /Users/evgenii.kniazev/projects/agent/agent
+uv run generate --prompt="your app description"
+```
+
+For local inference using `llama.cpp` first follow [local_inference_setup.md](local_inference_setup.md).
+
+## Experiment 1: Cost Comparison
+Compare API usage costs against completely local generation for a 2‑hour coding session.
+
+## Experiment 2: Generation Success Rate
+Test the same prompts with cloud vs local models and track completion time.
+
+## Experiment 3: Rate Limits Analysis
+Document rate limits for Claude Code, OpenAI, Gemini CLI and others.
+
+## Experiment 4: Parallelization Performance
+Measure tokens per second when running multiple instances on test hardware (MacBook Pro M4 and Threadripper PRO dual 3090).
+
+## Experiment 5: Model Capabilities Mapping
+Map open-source models to features of closed APIs (context size, vision, reasoning, function calling).
+
+## Experiment 6: Iteration Count Comparison
+Track how many iterations are required to build a standard reference app across models.
+
+## Experiment 7: Local Inference Tweaks
+Evaluate the Qwen3 30B model using the following command:
+
+```bash
+llama-cli -hf Qwen/Qwen3-30B-A3B:Q8_0 --jinja --color -ngl 99 -fa -sm row \
+  --temp 0.6 --top-k 20 --top-p 0.95 --min-p 0 \
+  --presence-penalty 1.5 -c 40960 -n 32768 --no-context-shift
+```
+
+This configuration is attributed to [OwnYourAI](https://www.linkedin.com/in/ownyourai?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app).
+
+Experiment with other models, quantization levels, and parameters (e.g., lower `--temp` for deterministic output) to find optimal local settings.
+

--- a/local_inference_setup.md
+++ b/local_inference_setup.md
@@ -1,0 +1,32 @@
+# Local Inference Setup
+
+This guide describes how to run app.build with fully local inference using `llama.cpp`.
+
+## Installation
+
+For macOS using Homebrew:
+
+```bash
+brew install llama.cpp
+```
+
+This installs the `llama-cli` command which provides fast local inference for
+many models.
+
+## Example Command
+
+To launch the Qwen3 30B model in MAX mode run:
+
+```bash
+llama-cli -hf Qwen/Qwen3-30B-A3B:Q8_0 --jinja --color -ngl 99 -fa -sm row \
+  --temp 0.6 --top-k 20 --top-p 0.95 --min-p 0 \
+  --presence-penalty 1.5 -c 40960 -n 32768 --no-context-shift
+```
+
+The flags above enable fast GPU inference and extended context windows. Adjust
+`--temp`, `--top-k` and `--top-p` to experiment with different creativity
+settings.
+
+Configuration courtesy of [OwnYourAI](https://www.linkedin.com/in/ownyourai?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app).
+
+


### PR DESCRIPTION
## Summary
- attribute the local inference configuration to OwnYourAI
- update README with acknowledgment of the source
- mention attribution in the experiment plan and setup guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d0a5fd7b0832b9cb432cf095108b2